### PR TITLE
2.8 new and edits

### DIFF
--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -60,6 +60,7 @@ class AreaManager:
             self.doc = 'No document.'
             self.status = 'IDLE'
             self.judgelog = []
+            self.evidlog = []
             self.current_music = ''
             self.current_music_player = ''
             self.current_music_player_ipid = -1
@@ -405,6 +406,17 @@ class AreaManager:
             if len(self.judgelog) >= 10:
                 self.judgelog = self.judgelog[1:]
             self.judgelog.append(
+                f'{client.char_name} ({client.ip}) {msg}.')
+
+        def add_to_evidlog(self, client, msg):
+            """
+            Append evidence changes or deletion to the evidence log (max 10 items).
+            :param client: event origin
+            :param msg: event message
+            """
+            if len(self.evidlog) >= 10:
+                self.evidlog = self.evidlog[1:]
+            self.evidlog.append(
                 f'{client.char_name} ({client.ip}) {msg}.')
 
         def add_music_playing(self, client, name, showname=''):

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -158,11 +158,14 @@ class ClientManager:
             printset = set(string.ascii_letters + string.digits + "~ -_.',")
             name_ws = name.replace(' ', '')
             if not name_ws or name_ws.isdigit():
+                self.send_ooc('Your OOC name must have at least one letter!')
                 return False
             if not set(name_ws).issubset(printset): #illegal chars in ooc name
+                self.send_ooc('Your OOC name cannot contain special characters!')
                 return False
             for client in self.server.client_manager.clients:
                 if client.name == name:
+                    self.send_ooc('That OOC name is already taken!')
                     return False
             return True
 

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -80,17 +80,17 @@ def ooc_cmd_help(client, arg):
 def ooc_cmd_kick(client, arg):
     """
     Kick a player.
-    Usage: /kick <ipid|*|**> [reason]
+    Usage: /kick <ipid|*|@> [reason]
     Special cases:
      - "*" kicks everyone in the current area.
-     - "**" kicks everyone in the server.
+     - "@" kicks everyone in the server.
     """
     if len(arg) == 0:
         raise ArgumentError(
             'You must specify a target. Use /kick <ipid> [reason]')
     elif arg[0] == '*':
         targets = [c for c in client.area.clients if c != client]
-    elif arg[0] == '**':
+    elif arg[0] == '@':
         targets = [c for c in client.server.client_manager.clients if c != client]
     else:
         targets = None
@@ -116,8 +116,12 @@ def ooc_cmd_kick(client, arg):
             c.send_command('KK', reason)
             c.disconnect()
     else:
-        client.send_ooc(
-            f'No targets with the IPID {ipid} were found.')
+        try:
+            client.send_ooc(
+                f'No targets with the IPID {ipid} were found.')
+        except:
+            client.send_ooc(
+                'No targets to kick!')
 
 
 def ooc_cmd_ban(client, arg):
@@ -215,31 +219,49 @@ def ooc_cmd_mute(client, arg):
     """
     Prevent a user from speaking in-character.
     Usage: /mute <ipid>
+    Special cases:
+     - "*" mutes everyone in the current area.
     """
     if len(arg) == 0:
         raise ArgumentError('You must specify a target. Use /mute <ipid>.')
-    args = list(arg.split(' '))
-    client.send_ooc(f'Attempting to mute {len(args)} IPIDs.')
-    for raw_ipid in args:
-        if raw_ipid.isdigit():
-            ipid = int(raw_ipid)
-            clients = client.server.client_manager.get_targets(
-                client, TargetType.IPID, ipid, False)
-            if (clients):
-                msg = 'Muted the IPID ' + str(ipid) + '\'s following clients:'
-                for c in clients:
-                    c.is_muted = True
-                    database.log_misc('mute', client, target=c)
-                    msg += ' ' + c.char_name + ' [' + str(c.id) + '],'
-                msg = msg[:-1]
-                msg += '.'
-                client.send_ooc(msg)
+    elif arg[0] == '*':
+        clients = client.area.clients
+    else:
+        clients = None
+
+    args = list(arg.split(' '))    
+    if clients is None:
+        client.send_ooc(f'Attempting to mute {len(args)} IPIDs.')
+        for raw_ipid in args:
+            if raw_ipid.isdigit():
+                ipid = int(raw_ipid)
+                clients = client.server.client_manager.get_targets(
+                    client, TargetType.IPID, ipid, False)
+                if (clients):
+                    msg = 'Muted the IPID ' + str(ipid) + '\'s following clients:'
+                    for c in clients:
+                        c.is_muted = True
+                        database.log_misc('mute', client, target=c)
+                        msg += ' ' + c.char_name + ' [' + str(c.id) + '],'
+                    msg = msg[:-1]
+                    msg += '.'
+                    client.send_ooc(msg)
+                else:
+                    client.send_ooc(
+                        "No targets found. Use /mute <ipid> <ipid> ... for mute.")
             else:
                 client.send_ooc(
-                    "No targets found. Use /mute <ipid> <ipid> ... for mute.")
-        else:
-            client.send_ooc(
-                f'{raw_ipid} does not look like a valid IPID.')
+                    f'{raw_ipid} does not look like a valid IPID.')
+    elif clients:
+        client.send_ooc('Attempting to mute the area.')
+        for c in clients:
+            if c.is_mod:
+                client.send_ooc('You were not muted as you are a mod.')
+                return
+            else:
+                c.is_muted = True
+            database.log_misc('mute', client, target=c)
+        client.send_ooc(f'Muted {len(args)} IPIDs.')
 
 
 @mod_only()
@@ -247,32 +269,46 @@ def ooc_cmd_unmute(client, arg):
     """
     Unmute a user.
     Usage: /unmute <ipid>
+    Special cases:
+     - "*" unmutes everyone in the current area.
     """
     if len(arg) == 0:
         raise ArgumentError('You must specify a target.')
+    elif arg[0] == '*':
+        clients = client.area.clients
+    else:
+        clients = None
+
     args = list(arg.split(' '))
-    client.send_ooc(f'Attempting to unmute {len(args)} IPIDs.')
-    for raw_ipid in args:
-        if raw_ipid.isdigit():
-            ipid = int(raw_ipid)
-            clients = client.server.client_manager.get_targets(
-                client, TargetType.IPID, ipid, False)
-            if (clients):
-                msg = f'Unmuted the IPID ${str(ipid)}\'s following clients:'
-                for c in clients:
-                    c.is_muted = False
-                    database.log_misc('unmute', client, target=c)
-                    msg += ' ' + c.char_name + ' [' + str(c.id) + '],'
-                msg = msg[:-1]
-                msg += '.'
-                client.send_ooc(msg)
+    if clients is None:
+        client.send_ooc(f'Attempting to unmute {len(args)} IPIDs.')
+        for raw_ipid in args:
+            if raw_ipid.isdigit():
+                ipid = int(raw_ipid)
+                clients = client.server.client_manager.get_targets(
+                    client, TargetType.IPID, ipid, False)
+                if (clients):
+                    msg = f'Unmuted the IPID ${str(ipid)}\'s following clients:'
+                    for c in clients:
+                        c.is_muted = False
+                        database.log_misc('unmute', client, target=c)
+                        msg += ' ' + c.char_name + ' [' + str(c.id) + '],'
+                    msg = msg[:-1]
+                    msg += '.'
+                    client.send_ooc(msg)
+                else:
+                    client.send_ooc(
+                        "No targets found. Use /unmute <ipid> <ipid> ... for unmute."
+                    )
             else:
                 client.send_ooc(
-                    "No targets found. Use /unmute <ipid> <ipid> ... for unmute."
-                )
-        else:
-            client.send_ooc(
-                f'{raw_ipid} does not look like a valid IPID.')
+                    f'{raw_ipid} does not look like a valid IPID.')
+    elif clients:
+        client.send_ooc('Attempting to unmute the area.')
+        for c in clients:
+            c.is_muted = False
+            database.log_misc('unmute', client, target=c)
+        client.send_ooc(f'Unmuted {len(args)} IPIDs.')
 
 
 def ooc_cmd_login(client, arg):

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -360,8 +360,10 @@ def ooc_cmd_mods(client, arg):
     Show the number of moderators online and in the area.
     Usage: /mods
     """
-    #client.send_area_info(-1, True)
-    client.send_ooc(
+    if client.is_mod:
+        client.send_area_info(-1, True)
+    else:
+        client.send_ooc(
         "There are {} mods online. {} is in the area.".format(client.server.area_manager.mods_online(),
                                                               len(client.area.get_mods())))
 

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -492,7 +492,7 @@ def ooc_cmd_lastchar(client, arg):
 @mod_only()
 def ooc_cmd_warn(client, arg):
     """
-    Warn a player.
+    Warn a player via OOC and a popup.
     Usage: /warn <ipid> [reason]
     Special cases:
      - "*" warns everyone in the current area.
@@ -522,9 +522,11 @@ def ooc_cmd_warn(client, arg):
             database.log_misc('warn', client, target=c, data={'reason': reason})
             client.send_ooc("{} was warned.".format(
                 c.char_name))
-            #BOING and OOC warning
-            c.send_command('ZZ', '===== [ ! ] =====\nYou have been warned for:\n' 
-                + reason + '\n===== [ ! ] =====')     
+            #Behold this absolute fucking mess
+            #BWOINK and OOC warning, mod call jury-rig
+            c.send_command('ZZ', '===== [ ! ] =====\nYou have been warned for:\n' + reason + '\n===== [ ! ] =====')
+            #Pop up, banned message jury-rig
+            c.send_command('BD', 'Just kidding. You are being warned for:\n' + reason)
     else:
         try:
             client.send_ooc(
@@ -532,3 +534,5 @@ def ooc_cmd_warn(client, arg):
         except:
             client.send_ooc(
                 'No targets to warn!')
+
+

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -27,8 +27,7 @@ __all__ = [
     'ooc_cmd_ooc_unmute',
     'ooc_cmd_bans',
     'ooc_cmd_baninfo',
-    'ooc_cmd_lastchar',
-    'ooc_cmd_warn'
+    'ooc_cmd_lastchar'
 ]
 
 

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -226,7 +226,7 @@ def ooc_cmd_mute(client, arg):
     if len(arg) == 0:
         raise ArgumentError('You must specify a target. Use /mute <ipid>.')
     elif arg[0] == '*':
-        clients = client.area.clients
+        clients = [c for c in client.area.clients if c.is_mod == False]
     else:
         clients = None
 
@@ -256,13 +256,10 @@ def ooc_cmd_mute(client, arg):
     elif clients:
         client.send_ooc('Attempting to mute the area.')
         for c in clients:
-            if c.is_mod:
-                client.send_ooc('You were not muted as you are a mod.')
-                return
-            else:
-                c.is_muted = True
+            c.is_muted = True
             database.log_misc('mute', client, target=c)
         client.send_ooc(f'Muted {len(args)} IPIDs.')
+        client.area.broadcast_ooc('Area has been muted.')
 
 
 @mod_only()
@@ -310,6 +307,7 @@ def ooc_cmd_unmute(client, arg):
             c.is_muted = False
             database.log_misc('unmute', client, target=c)
         client.send_ooc(f'Unmuted {len(args)} IPIDs.')
+        client.area.broadcast_ooc('Area has been unmuted.')
 
 
 def ooc_cmd_login(client, arg):
@@ -492,7 +490,7 @@ def ooc_cmd_lastchar(client, arg):
 @mod_only()
 def ooc_cmd_warn(client, arg):
     """
-    Warn a player via OOC and a popup.
+    Warn a player via an OOC message and popup.
     Usage: /warn <ipid> [reason]
     Special cases:
      - "*" warns everyone in the current area.

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -340,10 +340,11 @@ def ooc_cmd_area_kick(client, arg):
     """
     Remove a user from the current area and move them to another area.
     Usage: /area_kick <id> [area id]
+    If no area id is entered, user will be kicked to area 0.
     """
     if not arg:
         raise ClientError(
-            'You must specify a target. Use /area_kick <id> [area id #]')
+            'You must specify a target. Use /area_kick <id> [area id]')
     arg = arg.split(' ')
     if arg[0] == 'afk':
         trgtype = TargetType.AFK

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -152,10 +152,21 @@ def ooc_cmd_area(client, arg):
 
 def ooc_cmd_getarea(client, arg):
     """
-    Show information about the current area.
-    Usage: /getarea
+    Show information about the current or another area.
+    Usage: /getarea [area id]
     """
-    client.send_area_info(client.area.id, False)
+    if len(arg) == 0:
+        client.send_area_info(client.area.id, False)
+        return
+
+    try:
+        client.server.area_manager.get_area_by_id(int(arg[0]))
+        area = int(arg[0])
+        client.send_area_info(area, False)
+    except ValueError:
+        raise ArgumentError('Area ID must be a number.')
+    except (AreaError, ClientError):
+        raise
 
 
 def ooc_cmd_getareas(client, arg):

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -339,13 +339,11 @@ def ooc_cmd_uninvite(client, arg):
 def ooc_cmd_area_kick(client, arg):
     """
     Remove a user from the current area and move them to another area.
-    Usage: /area_kick <id> [destination]
+    Usage: /area_kick <id> [area id]
     """
-    if client.area.is_locked == client.area.Locked.FREE:
-        raise ClientError('Area isn\'t locked.')
     if not arg:
         raise ClientError(
-            'You must specify a target. Use /area_kick <id> [destination #]')
+            'You must specify a target. Use /area_kick <id> [area id #]')
     arg = arg.split(' ')
     if arg[0] == 'afk':
         trgtype = TargetType.AFK

--- a/server/commands/casing.py
+++ b/server/commands/casing.py
@@ -18,6 +18,7 @@ __all__ = [
     'ooc_cmd_blockwtce',
     'ooc_cmd_unblockwtce',
     'ooc_cmd_judgelog',
+    'ooc_cmd_evidlog',
     'ooc_cmd_afk'
 ]
 
@@ -305,6 +306,27 @@ def ooc_cmd_judgelog(client, arg):
         raise ServerError(
             'There have been no judge actions in this area since start of session.'
         )
-        
+
+
+@mod_only()
+def ooc_cmd_evidlog(client, arg):
+    """
+    List the last 10 uses of the evidence panel in the current area.
+    Usage: /evidlog
+    """
+    if len(arg) != 0:
+        raise ArgumentError('This command does not take any arguments.')
+    elog = client.area.evidlog
+    if len(elog) > 0:
+        elog_msg = '== Evidence Log =='
+        for x in elog:
+            elog_msg += f'\r\n{x}'
+        client.send_ooc(elog_msg)
+    else:
+        raise ServerError(
+    'There have been no evidence changes in this area since start of session.'
+    )
+
+
 def ooc_cmd_afk(client, arg):
     client.server.client_manager.toggle_afk(client)

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -914,6 +914,7 @@ class AOProtocol(asyncio.Protocol):
         # evi = Evidence(args[0], args[1], args[2], self.client.pos)
         self.client.area.evi_list.add_evidence(self.client, args[0], args[1],
                                                args[2], 'all')
+        self.client.area.add_to_evidlog(self.client, 'added evidence')
         database.log_room('evidence.add', self.client, self.client.area)
         self.client.area.broadcast_evidence_list()
 
@@ -929,6 +930,7 @@ class AOProtocol(asyncio.Protocol):
             return
         self.client.area.evi_list.del_evidence(
             self.client, self.client.evi_list[int(args[0])])
+        self.client.area.add_to_evidlog(self.client, 'deleted evidence')
         database.log_room('evidence.del', self.client, self.client.area)
         self.client.area.broadcast_evidence_list()
 
@@ -949,6 +951,7 @@ class AOProtocol(asyncio.Protocol):
 
         self.client.area.evi_list.edit_evidence(
             self.client, self.client.evi_list[int(args[0])], evi)
+        self.client.area.add_to_evidlog(self.client, 'edited evidence')
         database.log_room('evidence.edit', self.client, self.client.area)
         self.client.area.broadcast_evidence_list()
 


### PR DESCRIPTION
(Mod) **/evidlog** - Returns area's last 10 evidence changes with corresponding users.
(Mod) **/mute** * and **/unmute** * - Mutes and unmutes area (ignores logged in mods).
(Mod) **/ooc_mute** * and **/ooc_unmute** * - OOC mutes and unmutes area (ignores logged in mods).
(Mod) **/area_kick** [id] [area id] - No longer requires area to be locked to use.
(Mod) **/mods** - If logged in, /mods will show other online mods.

(All) **/getarea** [area id] - Returns user list of the specified area.

(Inactive) /warn - A bad meme. No bueno. 
Absolutely cursed.