### PR TITLE
/link shenanigans and various syntax updates

### DIFF
--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -56,7 +56,7 @@ def ooc_cmd_help(client, arg):
         If you don't understand a specific core feature, check the official
         repository for more information:
 
-        https://github.com/AttorneyOnlineVidya/tsuserver3-AOV
+        https://github.com/AttorneyOnlineVidya/tsuserver3-AOV 
 
         Available Categories:
         ''')

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -239,6 +239,7 @@ def ooc_cmd_link(client, arg):
     Mod usage: /link [choice]: <link>
     """
     links_list = client.server.misc_data
+    max = 10
     
     if len(arg) == 0:
         msg = 'Links available (use /link <option>):\n'
@@ -258,13 +259,16 @@ def ooc_cmd_link(client, arg):
                 except:
                     raise ArgumentError('Input error, link not set.\nUse /link <choice>: [link]')
             else:
-                try:
-                    client.server.misc_data[args[0]] = args[1]
-                    client.server.save_miscdata()
-                    client.send_ooc(f'Link "{args[0]}" created and set!')
-                    database.log_room(f'created "{args[0]}" link', client, client.area, message=args[1])
-                except:
-                    raise ArgumentError('Input error, link not set.\nUse /link <choice>: [link]')
+                if len(links_list) < max:
+                    try:
+                        client.server.misc_data[args[0]] = args[1]
+                        client.server.save_miscdata()
+                        client.send_ooc(f'Link "{args[0]}" created and set!')
+                        database.log_room(f'created "{args[0]}" link', client, client.area, message=args[1])
+                    except:
+                        raise ArgumentError('Input error, link not set.\nUse /link <choice>: [link]')
+                else:
+                    raise ClientError('Link list is full!')
         else:
             raise ClientError('You must be authorized to do that.')
     else:

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -17,10 +17,8 @@ __all__ = [
     'ooc_cmd_area_lock',
     'ooc_cmd_area_spectate',
     'ooc_cmd_area_unlock',
+    'ooc_cmd_link',
     'ooc_cmd_update',
-    'ooc_cmd_setupdate',
-    'ooc_cmd_thread',
-    'ooc_cmd_setthread',
     'ooc_cmd_invite',
     'ooc_cmd_uninvite',
     'ooc_cmd_area_kick',
@@ -233,7 +231,46 @@ def ooc_cmd_area_unlock(client, arg):
     client.area.unlock()
     client.send_ooc('Area is unlocked.')
 
+def ooc_cmd_link(client, arg):
+    """
+    Show a requested HTML link, a list of links or set a link.
+    Usage: /link [choice]
+    Mod usage: /link [choice]: <link>
+    """
+    links_list = client.server.misc_data
+    
+    if len(arg) == 0:
+        msg = 'Links available (use /link <option>):\n'
+        msg += "\n".join(links_list)
+        client.send_ooc(msg)
+    # bit sloppy but shrug
+    elif ':' in arg:
+        if client.is_mod:
+            args = arg.split(': ')
+            args[0] = args[0].lower()
+            if args[0] in links_list:
+                try:
+                    client.server.misc_data[args[0]] = args[1]
+                    client.server.save_miscdata()
+                    client.send_ooc(f'{args[0]} set!')
+                    database.log_room(f'set {args[0]}', client, client.area, message=args[1])
+                except:
+                    raise ArgumentError('Input error, link not set.\nUse /link <choice>: [link]')
+            else:
+                raise ArgumentError('Link not found. Use /link to see possible choices.')
+        else:
+            raise ClientError('You must be authorized to do that.')
+    else:
+        arg = arg.lower()
+        if arg in links_list:
+            try:
+                client.send_ooc('Latest {}: {}'.format(arg, client.server.misc_data[arg]))
+            except:
+                raise ClientError('Link has not been set!')
+        else:
+            raise ArgumentError('Link not found. Use /link to see possible choices.')
 
+# Quick access to update
 def ooc_cmd_update(client, arg):
     """
     See the link to the latest update.
@@ -243,42 +280,6 @@ def ooc_cmd_update(client, arg):
         client.send_ooc('Latest Update: {}'.format(client.server.misc_data['update']))
     except:
         raise ClientError('Update not set!')
-
-
-@mod_only()
-def ooc_cmd_setupdate(client, arg):
-    """
-    Set the link to the latest update.
-    Usage: /setupdate <link>
-    """
-    client.server.misc_data['update'] = arg
-    client.server.save_miscdata()
-    client.send_ooc('Update set!')
-    database.log_room('set update', client, client.area, message=arg)
-
-
-def ooc_cmd_thread(client, arg):
-    """
-    See the link to the latest thread.
-    Usage: /thread
-    """
-    try:
-        client.send_ooc('Current Thread: {}'.format(client.server.misc_data['thread']))
-    except:
-        raise ClientError('Thread not set!')
-
-
-@mod_only()
-def ooc_cmd_setthread(client, arg):
-    """
-    Set the link to the latest thread.
-    Usage: /setthread <link>
-    """
-    client.server.misc_data['thread'] = arg
-    client.server.save_miscdata()
-    client.send_ooc('Thread set!')
-    database.log_room('set thread', client, client.area, message=arg)
-
 
 @mod_only(area_owners=True)
 def ooc_cmd_invite(client, arg):

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -284,6 +284,7 @@ def ooc_cmd_link(client, arg):
                     client.send_ooc('Latest {}: {}'.format(choice, client.server.misc_data[arg]))
                 else:
                     client.send_ooc('{}: {}'.format(choice, client.server.misc_data[arg]))
+                    database.log_room(f'requested link', client, client.area, message=arg)
             except:
                 raise ClientError('Link has not been set!')
         else:

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -250,6 +250,7 @@ def ooc_cmd_link(client, arg):
         if client.is_mod:
             args = arg.split(': ')
             args[0] = args[0].lower()
+            args[0] = args[0].strip(' ')
             if args[0] in links_list:
                 try:
                     client.server.misc_data[args[0]] = args[1]
@@ -260,13 +261,16 @@ def ooc_cmd_link(client, arg):
                     raise ArgumentError('Input error, link not set.\nUse /link <choice>: [link]')
             else:
                 if len(links_list) < max:
-                    try:
-                        client.server.misc_data[args[0]] = args[1]
-                        client.server.save_miscdata()
-                        client.send_ooc(f'Link "{args[0]}" created and set!')
-                        database.log_room(f'created "{args[0]}" link', client, client.area, message=args[1])
-                    except:
-                        raise ArgumentError('Input error, link not set.\nUse /link <choice>: [link]')
+                    if args[0].isspace() or args[0] == "":
+                        raise ArgumentError('You must enter a link name.')
+                    else:
+                        try:
+                            client.server.misc_data[args[0]] = args[1]
+                            client.server.save_miscdata()
+                            client.send_ooc(f'Link "{args[0]}" created and set!')
+                            database.log_room(f'created "{args[0]}" link', client, client.area, message=args[1])
+                        except:
+                            raise ArgumentError('Input error, link not set.\nUse /link <choice>: [link]')
                 else:
                     raise ClientError('Link list is full!')
         else:

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -256,7 +256,7 @@ def ooc_cmd_link(client, arg):
                     client.server.misc_data[args[0]] = args[1]
                     client.server.save_miscdata()
                     client.send_ooc(f'{args[0]} set!')
-                    database.log_room(f'set {args[0]}', client, client.area, message=args[1])
+                    database.log_room(f'link.set "{args[0]}"', client, client.area, message=args[1])
                 except:
                     raise ArgumentError('Input error, link not set.\nUse /link <choice>: [link]')
             else:
@@ -268,7 +268,7 @@ def ooc_cmd_link(client, arg):
                             client.server.misc_data[args[0]] = args[1]
                             client.server.save_miscdata()
                             client.send_ooc(f'Link "{args[0]}" created and set!')
-                            database.log_room(f'created "{args[0]}" link', client, client.area, message=args[1])
+                            database.log_room(f'link.create "{args[0]}"', client, client.area, message=args[1])
                         except:
                             raise ArgumentError('Input error, link not set.\nUse /link <choice>: [link]')
                 else:
@@ -284,7 +284,7 @@ def ooc_cmd_link(client, arg):
                     client.send_ooc('Latest {}: {}'.format(choice, client.server.misc_data[arg]))
                 else:
                     client.send_ooc('{}: {}'.format(choice, client.server.misc_data[arg]))
-                    database.log_room(f'requested link', client, client.area, message=arg)
+                    database.log_room('link.request', client, client.area, message=arg)
             except:
                 raise ClientError('Link has not been set!')
         else:
@@ -307,7 +307,7 @@ def ooc_cmd_removelink(client, arg):
             del links_list[arg]
             client.server.save_miscdata()
             client.send_ooc(f'Deleted link "{arg}".')
-            database.log_room('deleted link', client, client.area, message=arg)
+            database.log_room('link.delete', client, client.area, message=arg)
         except:
             raise ClientError('Error, link has not been deleted.')
     else:

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -451,6 +451,15 @@ class AOProtocol(asyncio.Protocol):
                     "While that is not a blankpost, it is still pretty spammy. Try forming sentences."
                 )
                 return
+        if re.search(r'\|-.', frames_sfx):
+            self.client.send_ooc("Your char.ini FrameSFX has issues!")
+            return
+        if re.search(r'\|-.', frames_realization):
+            self.client.send_ooc("Your char.ini FrameRealize has issues!")
+            return
+        if re.search(r'\|-.', frames_shake):
+            self.client.send_ooc("Your char.ini FrameShake has issues!")
+            return
         if text.startswith('/a '):
             part = text.split(' ')
             try:

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -259,7 +259,7 @@ class TsuServer3:
 
     def save_miscdata(self):
         with open('config/data.yaml', 'w') as data:
-            json.dump(self.misc_data, data)
+            json.dump(self.misc_data, data, indent=4)
 
     def load_backgrounds(self):
         """Load the backgrounds list from a YAML file."""

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -471,6 +471,7 @@ class TsuServer3:
          - Backgrounds
          - Commands
          - Banlists
+         - Misc Data
         """
         with open('config/config.yaml', 'r') as cfg:
             cfg_yaml = yaml.safe_load(cfg)
@@ -501,6 +502,7 @@ class TsuServer3:
         self.load_music()
         self.load_backgrounds()
         self.load_ipranges()
+        self.load_miscdata()
 
         import server.commands
         importlib.reload(server.commands)


### PR DESCRIPTION
**/link** shows a list of available HTML links on the server (eg. 'update', 'thread') taken from data.yaml
**/link [option]** shows the link _[Logged]_
(Mod) **/link [option]: [arg]** will set a link or create a new one (10 links max for sanity sake) _[Logged]_
All slammed into one command because fuck having a separate /setlink command like some kind of chump let's live a little.
(Oh god please test this)
(Mod) **/removelink [option]** removes a link option from the list, deleting it from data.yaml _[Logged]_

Removes /thread, /setthread and /setupdate
/update remains as a backup link. Just in case.

Add miscdata (data.yaml) to /refresh so it can be changed without server update. Just in case.
Also add an indent to data.yaml so it can actually be read by human eyes.
Vital emergency ultra-important fix of /help link so it doesn't cross into the word "Available" thus breaking the link because that's really annoying.
Added Called by the Grave to the Limited list.