### PR TITLE
BEEG 2 fix boogaloo

### DIFF
--- a/config_sample/data.yaml
+++ b/config_sample/data.yaml
@@ -1,1 +1,2 @@
-{"thread": "www.google.com", "update": "http://aovidya.com"}
+thread: www.google.com
+update: http://aovidya.pw

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -207,9 +207,9 @@ class AreaManager:
             """Mark the area as locked."""
             self.is_locked = self.Locked.LOCKED
             for i in self.clients:
-                self.invite_list[i.id] = None
+                self.invite_list[i.ipid] = None
             for i in self.owners:
-                self.invite_list[i.id] = None
+                self.invite_list[i.ipid] = None
             self.server.area_manager.send_arup_lock()
             self.broadcast_ooc('This area is locked now.')
 

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -173,6 +173,7 @@ class AreaManager:
                 self.change_status('IDLE')
                 self.unlock()
                 client.area.owners = []
+                self.server.area_manager.send_arup_cms()
             if client.char_id != -1:
                 database.log_room('area.leave', client, self)
 

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -258,7 +258,7 @@ class ClientManager:
             Returns:
                 int: how many seconds the client must wait to change music
             """
-            if self.is_mod or self in self.area.owners:
+            if self.is_mod:
                 return 0
             if self.mus_mute_time:
                 if time.time() - self.mus_mute_time < self.server.config[

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -509,13 +509,6 @@ def ooc_cmd_unmod(client, arg):
     client.send_ooc('you\'re not a mod now')
     client.send_command('AUTH', '-1')
 
-@mod_only()
-def ooc_cmd_mods(client, arg):
-    """
-    Show a list of moderators online.
-    Usage: /mods
-    """
-    client.send_area_info(-1, True)
 
 @mod_only()
 def ooc_cmd_ooc_mute(client, arg):

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -255,6 +255,9 @@ def ooc_cmd_link(client, arg):
     """
     links_list = client.server.misc_data
     max = 10
+
+    if links_list is None:
+        raise ClientError('data.yaml is null. Tell someone.')
     
     if len(arg) == 0:
         msg = 'Links available (use /link <option>):\n'
@@ -385,7 +388,7 @@ def ooc_cmd_uninvite(client, arg):
                     "You were removed from the area whitelist.")
                 database.log_room('uninvite', client, client.area, target=c)
                 if client.area.is_locked != client.area.Locked.FREE:
-                    client.area.invite_list.pop(c.id)
+                    client.area.invite_list.pop(c.ipid)
         except AreaError:
             raise
         except ClientError:
@@ -434,7 +437,7 @@ def ooc_cmd_area_kick(client, arg):
                     f"You were kicked from the area to area {output}.")
                 database.log_room('area_kick', client, client.area, target=c, message=output)
                 if client.area.is_locked != client.area.Locked.FREE:
-                    client.area.invite_list.pop(c.id)
+                    client.area.invite_list.pop(c.ipid)
         except AreaError:
             raise
         except ClientError:

--- a/server/commands/music.py
+++ b/server/commands/music.py
@@ -163,6 +163,19 @@ def ooc_cmd_play(client, arg):
         raise ArgumentError('You must specify a song.')
     if YOUTUBE_RE.search(arg):
         raise ArgumentError('You cannot use YouTube links. You may use direct links to MP3, Ogg, or M3U streams.')
+    if client.is_muted:
+        raise ArgumentError('You are muted by a moderator.')
+    if not client.is_dj:
+            raise ArgumentError('You were blockdj\'d by a moderator.')
+    if client.area.cannot_ic_interact(client):
+            raise ArgumentError(
+                "You are not on the area's invite list, and thus, you cannot change music!"
+            )
+    if client.change_music_cd():
+        if (len(client.area.clients) != 1):
+            raise ArgumentError(
+                f'You changed the song too many times. Please try again after {int(client.change_music_cd())} seconds.'
+            )
     client.area.play_music(arg, client.char_id, 0) #don't loop it
     client.area.add_music_playing(client, arg)
     client.area.add_to_musiclog(client, f'played {arg}')


### PR DESCRIPTION
Delete the dumb mod only /mods so ours works again because that's some wack ass nonsense my dude
/invite /uninvite, /cm fixes (hopefully)
Remember to have something in data.yaml or else
If an area is empty, CMs are auto removed - Area list will now update to show this to avoid ghosts.
Checks on /play usages, now affected by mute, blockdj and cooldown.
Increased damage on Sol Badguy's F. Slash.