### PR TITLE
/format command and minor changes

### DIFF
--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -231,6 +231,7 @@ def ooc_cmd_area_spectate(client, arg):
         client.send_ooc('Area is already spectatable.')
     elif client in client.area.owners or client.is_mod:
         client.area.spectator()
+        database.log_room('area.spectate', client, client.area, message=None)
     else:
         raise ClientError('Only CM can make the area spectatable.')
 
@@ -244,6 +245,7 @@ def ooc_cmd_area_unlock(client, arg):
     elif client in client.area.owners or client.is_mod:
         client.area.unlock()
         client.send_ooc('Area is unlocked.')
+        database.log_room('area.unlock', client, client.area, message=None)
     else:
         raise ClientError('Only CM can unlock area.')
 

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -355,6 +355,9 @@ def ooc_cmd_invite(client, arg):
     try:
         c = client.server.client_manager.get_targets(client, TargetType.ID,
                                                      int(arg), False)[0]
+        if c.ipid in client.area.invite_list:
+            client.send_ooc("This user has already been invited to the area!")
+            return
         client.area.invite_list[c.ipid] = None
         client.send_ooc('{} is invited to your area.'.format(
             c.char_name))
@@ -381,6 +384,8 @@ def ooc_cmd_uninvite(client, arg):
     if targets:
         try:
             for c in targets:
+                if c.ipid not in client.area.invite_list:
+                    raise ArgumentError('This user has already been uninvited from the area!')
                 client.send_ooc(
                     "You have removed {} from the whitelist.".format(
                         c.char_name))

--- a/server/commands/casing.py
+++ b/server/commands/casing.py
@@ -28,7 +28,8 @@ __all__ = [
     'ooc_cmd_keywords',
     'ooc_cmd_testimony',
     'ooc_cmd_cleartesti',
-    'ooc_cmd_afk'
+    'ooc_cmd_afk',
+    'ooc_cmd_format'
 ]
 
 
@@ -392,6 +393,30 @@ def ooc_cmd_evidlog(client, arg):
 
 def ooc_cmd_afk(client, arg):
     client.server.client_manager.toggle_afk(client)
+
+
+def ooc_cmd_format(client, arg):
+    '''
+    Prints the available IC markdown for text formatting, including colors, alignment and actions.
+    Usage: /format <option>
+    '''
+    formats = {
+        "colors": "`Green`, ~Red~, |Orange|, [Gray], (Blue), ºYellowº, №Pink№, √Cyan√",
+        "align": "~~Center, ~>Right align, \\n New line",
+        "action": "\s Shake, \\f Flash"
+    }
+
+    option = ['colors', 'align', 'action']
+
+    if len(arg) == 0:
+        client.send_ooc(f'All formatting options:\n{formats["colors"]}\n {formats["align"]}\n {formats["action"]}')
+    else:
+        choice = arg.lower()
+        if choice in option:
+            client.send_ooc(f'{arg.capitalize()} formatting:\n {formats[choice]}')
+        else:
+            client.send_ooc(f'Format options include: {option}')
+
 
 def ooc_cmd_prompt(client, arg):
     """

--- a/server/commands/casing.py
+++ b/server/commands/casing.py
@@ -409,13 +409,13 @@ def ooc_cmd_format(client, arg):
     option = ['colors', 'align', 'action']
 
     if len(arg) == 0:
-        client.send_ooc(f'All formatting options:\n{formats["colors"]}\n {formats["align"]}\n {formats["action"]}')
+        client.send_ooc(f'All IC formatting options:\n{formats["colors"]}\n {formats["align"]}\n {formats["action"]}')
     else:
         choice = arg.lower()
         if choice in option:
             client.send_ooc(f'{arg.capitalize()} formatting:\n {formats[choice]}')
         else:
-            client.send_ooc(f'Format options include: {option}')
+            client.send_ooc(f'Formatting options include: {option}')
 
 
 def ooc_cmd_prompt(client, arg):


### PR DESCRIPTION
/format prints the different colour, alignment and action (shake, flash) formatting options for IC.
Throw up an error if you try to /invite or /uninvite someone who is already on/off area whitelist to avoid OOC spam.
Applied logging to /area_spectate and /area_unlock. No real reason for this one, but hey maybe it'll come in handy one day?
Added lemon to cereal.